### PR TITLE
Exclude incomplete season dues from net earnings

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -495,6 +495,14 @@ const FantasyFootballApp = () => {
       }
     });
 
+    const mostRecentYear = teamSeasons.length > 0
+      ? Math.max(...teamSeasons.map(s => s.year))
+      : null;
+    const currentYearSeasons = seasonsByYear[mostRecentYear] || [];
+    const currentSeasonInProgress = currentYearSeasons.some(
+      s => !s.regular_season_rank || s.regular_season_rank <= 0
+    );
+
     teamSeasons.forEach(season => {
       if (records[season.name_id]) {
         const record = records[season.name_id];
@@ -503,8 +511,12 @@ const FantasyFootballApp = () => {
         record.totalPointsFor += season.points_for;
         record.totalPointsAgainst += season.points_against;
         record.totalPayout += season.payout || 0;
-        record.totalDues += season.dues || 250;
-        record.totalDuesChumpion += season.dues_chumpion || 0;
+        const isCurrentIncomplete =
+          season.year === mostRecentYear && currentSeasonInProgress;
+        record.totalDues += isCurrentIncomplete ? 0 : (season.dues || 250);
+        record.totalDuesChumpion += isCurrentIncomplete
+          ? 0
+          : (season.dues_chumpion || 0);
         record.seasons += 1;
         record.gamesPlayed += (season.wins + season.losses);
         


### PR DESCRIPTION
## Summary
- Skip counting dues for the current season when calculating manager net earnings if that season hasn't finished yet

## Testing
- `npm install` (failed: 403 Forbidden fetching dependency)
- `npm test -- --watchAll=false` (failed: react-scripts: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a3c7d7e6b08332b2b250561de5d200