### PR TITLE
Exclude incomplete season dues from net earnings

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -495,6 +495,14 @@ const FantasyFootballApp = () => {
       }
     });
 
+    const mostRecentYear = teamSeasons.length > 0
+      ? Math.max(...teamSeasons.map(s => s.year))
+      : null;
+    const currentYearSeasons = seasonsByYear[mostRecentYear] || [];
+    const currentSeasonInProgress = currentYearSeasons.some(
+      s => !s.playoff_finish || s.playoff_finish <= 0
+    );
+
     teamSeasons.forEach(season => {
       if (records[season.name_id]) {
         const record = records[season.name_id];
@@ -503,8 +511,12 @@ const FantasyFootballApp = () => {
         record.totalPointsFor += season.points_for;
         record.totalPointsAgainst += season.points_against;
         record.totalPayout += season.payout || 0;
-        record.totalDues += season.dues || 250;
-        record.totalDuesChumpion += season.dues_chumpion || 0;
+        const isCurrentIncomplete =
+          season.year === mostRecentYear && currentSeasonInProgress;
+        record.totalDues += isCurrentIncomplete ? 0 : (season.dues || 250);
+        record.totalDuesChumpion += isCurrentIncomplete
+          ? 0
+          : (season.dues_chumpion || 0);
         record.seasons += 1;
         record.gamesPlayed += (season.wins + season.losses);
         
@@ -561,14 +573,15 @@ const FantasyFootballApp = () => {
 
   const getCurrentYearChumpionDues = () => {
     // Find the chumpion for the current year (highest regular_season_rank)
-    const currentYearSeasonsWithRank = currentYearSeasons.filter(
-      s => s.regular_season_rank && s.regular_season_rank > 0
+    const currentYearSeasonsWithFinish = currentYearSeasons.filter(
+      s => s.playoff_finish && s.playoff_finish > 0
     );
-    // Only return dues if the season is complete (all teams have a rank)
-    if (currentYearSeasonsWithRank.length !== currentYearSeasons.length) return 0;
+    // Only return dues if the season is complete (all teams have a playoff finish)
+    if (currentYearSeasonsWithFinish.length !== currentYearSeasons.length) return 0;
 
-    const currentChumpionSeason = currentYearSeasonsWithRank.reduce((worst, current) =>
-      current.regular_season_rank > worst.regular_season_rank ? current : worst
+    const currentChumpionSeason = currentYearSeasonsWithFinish.reduce(
+      (worst, current) =>
+        current.regular_season_rank > worst.regular_season_rank ? current : worst
     );
     return currentChumpionSeason?.dues_chumpion || 0;
   };
@@ -624,14 +637,14 @@ const FantasyFootballApp = () => {
   const currentChampion = currentYearSeasons.find(s => s.playoff_finish === 1);
   
   // Find current chumpion (highest regular_season_rank number)
-  const currentYearSeasonsWithRank = currentYearSeasons.filter(
-    s => s.regular_season_rank && s.regular_season_rank > 0
+  const currentYearSeasonsWithFinish = currentYearSeasons.filter(
+    s => s.playoff_finish && s.playoff_finish > 0
   );
   const currentChumpion =
     currentChampion &&
-    currentYearSeasonsWithRank.length === currentYearSeasons.length &&
-    currentYearSeasonsWithRank.length > 0
-      ? currentYearSeasonsWithRank.reduce((worst, current) =>
+    currentYearSeasonsWithFinish.length === currentYearSeasons.length &&
+    currentYearSeasonsWithFinish.length > 0
+      ? currentYearSeasonsWithFinish.reduce((worst, current) =>
           current.regular_season_rank > worst.regular_season_rank ? current : worst
         )
       : null;


### PR DESCRIPTION
## Summary
- Ignore season dues and chumpion dues until every team has a playoff finish recorded
- Base current season chumpion message on playoff completion

## Testing
- `npm install` (failed: 403 Forbidden - GET https://registry.npmjs.org/tsutils)
- `npm test -- --watchAll=false` (failed: react-scripts: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a3c7d7e6b08332b2b250561de5d200