### PR TITLE
Hide playoff bracket until seeded and remove losers bracket

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -121,7 +121,12 @@ const FantasyFootballApp = () => {
       const response = await fetch(`${API_BASE_URL}/seasons/${year}/playoffs`);
       if (response.ok) {
         const data = await response.json();
-        setPlayoffBracket(data.bracket || []);
+        const hasBracket = Array.isArray(data.bracket) &&
+          data.bracket.some(round =>
+            Array.isArray(round.matchups) &&
+            round.matchups.some(m => m.home && m.away)
+          );
+        setPlayoffBracket(hasBracket ? data.bracket : []);
       }
     } catch (error) {
       console.error('Error fetching playoff bracket:', error);

--- a/src/components/PlayoffBracket.js
+++ b/src/components/PlayoffBracket.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const PlayoffBracket = ({ rounds = [] }) => {
-  if (!rounds || rounds.length === 0) return null;
+  if (!rounds || rounds.length === 0 || rounds.every(r => !r.matchups || r.matchups.length === 0)) return null;
 
   return (
     <div className="overflow-x-auto">
@@ -9,18 +9,18 @@ const PlayoffBracket = ({ rounds = [] }) => {
         {rounds.map((round, roundIdx) => (
           <div key={roundIdx} className="flex flex-col space-y-6">
             {round.matchups.map((m, idx) => {
-              const homeWin = m.home.points > m.away.points;
-              const awayWin = m.away.points > m.home.points;
+              const homeWin = m.home && m.away ? m.home.points > m.away.points : false;
+              const awayWin = m.home && m.away ? m.away.points > m.home.points : false;
               return (
                 <div key={idx} className="relative">
                   <div className="bg-gray-50 border border-gray-200 rounded-lg p-2 w-40 sm:w-48 text-xs sm:text-sm">
                     <div className={`flex justify-between ${homeWin ? 'font-semibold text-green-600' : ''}`}>
-                      <span className="truncate">{m.home.manager_name}</span>
-                      <span>{m.home.points}</span>
+                      <span className="truncate">{m.home?.manager_name}</span>
+                      <span>{m.home?.points ?? ''}</span>
                     </div>
                     <div className={`flex justify-between ${awayWin ? 'font-semibold text-green-600' : ''}`}>
-                      <span className="truncate">{m.away.manager_name}</span>
-                      <span>{m.away.points}</span>
+                      <span className="truncate">{m.away?.manager_name}</span>
+                      <span>{m.away?.points ?? ''}</span>
                     </div>
                   </div>
                   {roundIdx < rounds.length - 1 && (


### PR DESCRIPTION
## Summary
- Avoid showing playoff bracket until winners bracket has seeded teams
- Drop losers bracket placement logic from playoff results
- Guard bracket component against empty or partial matchups

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e485c66883329f01966e3e56469e