### PR TITLE
feat: filter zero-medal managers from rankings

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -671,11 +671,13 @@ const FantasyFootballApp = () => {
       : null;
 
   // Medal Rankings: Sort by medals only, don't separate active/inactive
-  const medalRankings = Object.values(allRecords).sort((a, b) => {
-    if (b.championships !== a.championships) return b.championships - a.championships;
-    if (b.secondPlace !== a.secondPlace) return b.secondPlace - a.secondPlace;
-    return b.thirdPlace - a.thirdPlace;
-  });
+  const medalRankings = Object.values(allRecords)
+    .filter(record => record.totalMedals > 0)
+    .sort((a, b) => {
+      if (b.championships !== a.championships) return b.championships - a.championships;
+      if (b.secondPlace !== a.secondPlace) return b.secondPlace - a.secondPlace;
+      return b.thirdPlace - a.thirdPlace;
+    });
 
   // Chumpion Rankings: only include managers with chumpionships and sort by count, then by seasons (fewer seasons = worse ranking)
   const chumpionRankings = Object.values(allRecords)

--- a/src/components/FantasyFootballApp_backup.js
+++ b/src/components/FantasyFootballApp_backup.js
@@ -563,11 +563,13 @@ const FantasyFootballApp = () => {
     : null;
 
   // Medal Rankings: Sort by medals only, don't separate active/inactive
-  const medalRankings = Object.values(allRecords).sort((a, b) => {
-    if (b.championships !== a.championships) return b.championships - a.championships;
-    if (b.secondPlace !== a.secondPlace) return b.secondPlace - a.secondPlace;
-    return b.thirdPlace - a.thirdPlace;
-  });
+  const medalRankings = Object.values(allRecords)
+    .filter(record => record.totalMedals > 0)
+    .sort((a, b) => {
+      if (b.championships !== a.championships) return b.championships - a.championships;
+      if (b.secondPlace !== a.secondPlace) return b.secondPlace - a.secondPlace;
+      return b.thirdPlace - a.thirdPlace;
+    });
 
   // Chumpion Rankings: Sort by chumpionships, then by seasons (fewer seasons = worse ranking)
   const chumpionRankings = Object.values(allRecords).sort((a, b) => {


### PR DESCRIPTION
## Summary
- filter medal rankings to exclude managers with zero total medals

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a471440e5c8332b2253bf658e073af