### PR TITLE
Align Hall of Records layouts across devices

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -1006,12 +1006,10 @@ const FantasyFootballApp = () => {
                       key={manager.name}
                       className="p-3 sm:p-4 rounded-lg border-2 bg-gradient-to-r from-white to-gray-50 border-gray-200 hover:border-gray-300 hover:shadow-md transition-all duration-200"
                     >
-                      {/* Mobile Layout - Stacked */}
-                      <div className="sm:hidden">
-                        {/* Mobile Header */}
-                        <div className="flex items-center justify-between mb-3">
-                          <div className="flex items-center space-x-3">
-                            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex items-center space-x-3 sm:space-x-4 min-w-0 flex-1 mb-3 sm:mb-0">
+                          <div
+                            className={`w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-sm sm:text-base font-bold ${
                               index === 0
                                 ? 'bg-yellow-500 text-white shadow-lg'
                                 : index === 1
@@ -1019,96 +1017,39 @@ const FantasyFootballApp = () => {
                                 : index === 2
                                 ? 'bg-amber-600 text-white shadow-md'
                                 : 'bg-blue-100 text-blue-800'
-                            }`}>
-                              #{index + 1}
-                            </div>
-                            <div className="min-w-0 flex-1">
-                              <h4 className="font-bold text-base truncate text-gray-900">
-                                {manager.name}
-                              </h4>
-                              <p className="text-xs text-gray-600">
-                                {manager.gamesPlayed} games played
-                              </p>
-                            </div>
-                          </div>
-                          <div className="text-right flex-shrink-0">
-                            <p className="font-bold text-sm text-blue-600">
-                              {manager.pointsPerGame.toFixed(1)} PPG
-                            </p>
-                            <p className="text-xs text-gray-600">
-                              {manager.totalPointsFor.toLocaleString()} total
-                            </p>
-                          </div>
-                        </div>
-
-                        {/* Mobile Medals */}
-                        <div className="grid grid-cols-3 gap-2 mb-2">
-                          <div className="text-center">
-                            <div className="text-yellow-500 font-bold text-lg">{manager.championships}</div>
-                            <div className="text-xs text-gray-500">🥇</div>
-                          </div>
-                          <div className="text-center">
-                            <div className="text-gray-500 font-bold text-lg">{manager.secondPlace}</div>
-                            <div className="text-xs text-gray-500">🥈</div>
-                          </div>
-                          <div className="text-center">
-                            <div className="text-amber-600 font-bold text-lg">{manager.thirdPlace}</div>
-                            <div className="text-xs text-gray-500">🥉</div>
-                          </div>
-                        </div>
-
-                        {/* Mobile Additional Stats */}
-                        <div className="flex justify-between text-xs text-gray-600 pt-2 border-t border-gray-200">
-                          <span>{manager.totalWins}-{manager.totalLosses} ({(manager.winPct * 100).toFixed(1)}%)</span>
-                          <span>{manager.totalMedals} total medals</span>
-                        </div>
-                      </div>
-
-                      {/* Desktop Layout - Single Row */}
-                      <div className="hidden sm:flex sm:items-center sm:justify-between">
-                        <div className="flex items-center space-x-4 min-w-0 flex-1">
-                          <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold ${
-                            index === 0
-                              ? 'bg-yellow-500 text-white shadow-lg'
-                              : index === 1
-                              ? 'bg-gray-400 text-white shadow-md'
-                              : index === 2
-                              ? 'bg-amber-600 text-white shadow-md'
-                              : 'bg-blue-100 text-blue-800'
-                          }`}>
+                            }`}
+                          >
                             #{index + 1}
                           </div>
                           <div className="min-w-0 flex-1">
-                            <h4 className="font-bold text-lg truncate text-gray-900">
+                            <h4 className="font-bold text-base sm:text-lg truncate text-gray-900">
                               {manager.name}
                             </h4>
-                            <p className="text-sm text-gray-600">
+                            <p className="text-xs sm:text-sm text-gray-600">
                               {manager.totalWins}-{manager.totalLosses} ({(manager.winPct * 100).toFixed(1)}%) • {manager.gamesPlayed} games
                             </p>
                           </div>
                         </div>
-
-                        <div className="flex items-center space-x-6 flex-shrink-0">
+                        <div className="flex items-center justify-between sm:justify-end space-x-4 sm:space-x-6 flex-shrink-0 w-full sm:w-auto">
                           <div className="flex items-center space-x-4">
                             <div className="text-center">
-                              <div className="text-yellow-500 font-bold text-xl">{manager.championships}</div>
+                              <div className="text-yellow-500 font-bold text-lg sm:text-xl">{manager.championships}</div>
                               <div className="text-xs text-gray-500">🥇</div>
                             </div>
                             <div className="text-center">
-                              <div className="text-gray-500 font-bold text-xl">{manager.secondPlace}</div>
+                              <div className="text-gray-500 font-bold text-lg sm:text-xl">{manager.secondPlace}</div>
                               <div className="text-xs text-gray-500">🥈</div>
                             </div>
                             <div className="text-center">
-                              <div className="text-amber-600 font-bold text-xl">{manager.thirdPlace}</div>
+                              <div className="text-amber-600 font-bold text-lg sm:text-xl">{manager.thirdPlace}</div>
                               <div className="text-xs text-gray-500">🥉</div>
                             </div>
                           </div>
-
                           <div className="text-right">
-                            <p className="font-bold text-base text-blue-600">
+                            <p className="font-bold text-sm sm:text-base text-blue-600">
                               {manager.pointsPerGame.toFixed(1)} PPG
                             </p>
-                            <p className="text-sm text-gray-600">
+                            <p className="text-xs sm:text-sm text-gray-600">
                               {manager.totalMedals} total medals
                             </p>
                           </div>
@@ -1126,9 +1067,9 @@ const FantasyFootballApp = () => {
                   <span>Chumpion Count Rankings</span>
                 </h3>
 
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3">
+                <div className="space-y-2 sm:space-y-3">
                   {chumpionRankings.map((manager, index) => (
-                    <div key={manager.name} className="p-3 sm:p-4 rounded-lg border bg-white border-gray-200">
+                    <div key={manager.name} className="w-full p-3 sm:p-4 rounded-lg border-2 bg-white border-gray-200">
                       <div className="flex items-center justify-between mb-2">
                         <div className="flex items-center space-x-2 min-w-0 flex-1">
                           <span className="font-bold text-base sm:text-lg flex-shrink-0">#{index + 1}</span>
@@ -1160,17 +1101,17 @@ const FantasyFootballApp = () => {
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
               {/* Win Percentage Rankings */}
               <div className="bg-white rounded-xl shadow-lg p-4 sm:p-6">
-                <h3 className="text-lg sm:text-xl font-bold text-gray-900 mb-4 sm:mb-6 flex items-center space-x-2">
+                <h3 className="text-lg sm:text-xl font-bold text-gray-900 mb-3 sm:mb-5 flex items-center space-x-2">
                   <BarChart3 className="w-5 h-5 text-blue-500" />
                   <span>Win Percentage Rankings</span>
                 </h3>
 
-                <div className="space-y-2 sm:space-y-3">
+                <div className="space-y-1 sm:space-y-2">
                   {winPctRankings.map((manager, index) => (
-                    <div key={manager.name} className={`p-3 sm:p-4 rounded-lg border ${
+                    <div key={manager.name} className={`p-2 sm:p-3 rounded-lg border ${
                       manager.active ? 'bg-white border-gray-200' : 'bg-gray-50 border-gray-300 opacity-75'
                     }`}>
-                      <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center justify-between mb-1">
                         <div className="flex items-center space-x-2 min-w-0 flex-1">
                           <span className="font-bold text-base sm:text-lg flex-shrink-0">#{index + 1}</span>
                           <span className={`font-semibold text-sm sm:text-base truncate ${manager.active ? 'text-gray-900' : 'text-gray-500'}`}>
@@ -1196,17 +1137,17 @@ const FantasyFootballApp = () => {
 
               {/* Points Per Game Rankings */}
               <div className="bg-white rounded-xl shadow-lg p-4 sm:p-6">
-                <h3 className="text-lg sm:text-xl font-bold text-gray-900 mb-4 sm:mb-6 flex items-center space-x-2">
+                <h3 className="text-lg sm:text-xl font-bold text-gray-900 mb-3 sm:mb-5 flex items-center space-x-2">
                   <TrendingUp className="w-5 h-5 text-green-500" />
                   <span>Points Per Game Rankings</span>
                 </h3>
 
-                <div className="space-y-2 sm:space-y-3">
+                <div className="space-y-1 sm:space-y-2">
                   {ppgRankings.map((manager, index) => (
-                    <div key={manager.name} className={`p-3 sm:p-4 rounded-lg border ${
+                    <div key={manager.name} className={`p-2 sm:p-3 rounded-lg border ${
                       manager.active ? 'bg-white border-gray-200' : 'bg-gray-50 border-gray-300 opacity-75'
                     }`}>
-                      <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center justify-between mb-1">
                         <div className="flex items-center space-x-2 min-w-0 flex-1">
                           <span className="font-bold text-base sm:text-lg flex-shrink-0">#{index + 1}</span>
                           <span className={`font-semibold text-sm sm:text-base truncate ${manager.active ? 'text-gray-900' : 'text-gray-500'}`}>


### PR DESCRIPTION
## Summary
- Align medal and chumpion rankings layouts across desktop and mobile
- Reduce spacing for win percentage and points-per-game tables

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49ec9a4b08332a0007da13b1ed2d5