### PR TITLE
Add Keepers tab with Sleeper API rosters

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -141,6 +141,41 @@ app.get('/api/seasons/:year/playoffs', (req, res) => {
   });
 });
 
+// Get final rosters for a specific season
+app.get('/api/seasons/:year/keepers', (req, res) => {
+  const year = req.params.year;
+  const query = 'SELECT league_id FROM league_settings WHERE year = ?';
+  db.get(query, [year], async (err, row) => {
+    if (err) {
+      res.status(500).json({ error: err.message });
+      return;
+    }
+    if (!row || !row.league_id) {
+      res.status(404).json({ error: 'League ID not found for year' });
+      return;
+    }
+    try {
+      const managers = await new Promise((resolve, reject) => {
+        db.all(
+          `SELECT m.full_name, COALESCE(msi.sleeper_user_id, m.sleeper_user_id) as sleeper_user_id
+           FROM managers m
+           LEFT JOIN manager_sleeper_ids msi ON m.name_id = msi.name_id AND msi.season = ?`,
+          [year],
+          (err, rows) => {
+            if (err) reject(err);
+            else resolve(rows);
+          }
+        );
+      });
+
+      const rosters = await sleeperService.getFinalRosters(row.league_id, managers);
+      res.json({ rosters });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+});
+
 // Get team seasons by manager
 app.get('/api/managers/:nameId/seasons', (req, res) => {
   const nameId = req.params.nameId;


### PR DESCRIPTION
## Summary
- add Sleeper service helper and API route to fetch league rosters for any season
- create Keepers tab with year selector to display each team's final roster

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5476ce69083329c0915a7ddea635c