### PR TITLE
Add migration for keeper trade columns

### DIFF
--- a/backend/scripts/initDatabase.js
+++ b/backend/scripts/initDatabase.js
@@ -133,6 +133,32 @@ db.serialize(() => {
     }
   });
 
+  // Add trade columns if they don't exist (for existing databases)
+  console.log('🔧 Checking for keeper trade columns...');
+  db.run(`
+    ALTER TABLE keepers ADD COLUMN trade_from_roster_id INTEGER;
+  `, (err) => {
+    if (err && err.message.includes('duplicate column name')) {
+      console.log('ℹ️  trade_from_roster_id column already exists');
+    } else if (err) {
+      console.error('❌ Error adding trade_from_roster_id column:', err.message);
+    } else {
+      console.log('✅ Added trade_from_roster_id column');
+    }
+  });
+
+  db.run(`
+    ALTER TABLE keepers ADD COLUMN trade_amount REAL;
+  `, (err) => {
+    if (err && err.message.includes('duplicate column name')) {
+      console.log('ℹ️  trade_amount column already exists');
+    } else if (err) {
+      console.error('❌ Error adding trade_amount column:', err.message);
+    } else {
+      console.log('✅ Added trade_amount column');
+    }
+  });
+
   // Create rules table for future use
   console.log('📊 Creating rules table...');
   db.run(`

--- a/backend/scripts/migrations/addKeeperTradeColumns.js
+++ b/backend/scripts/migrations/addKeeperTradeColumns.js
@@ -1,0 +1,41 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = path.join(__dirname, '..', '..', 'data', 'fantasy_football.db');
+const db = new sqlite3.Database(dbPath);
+
+console.log('🚀 Running migration: add trade columns to keepers table...');
+
+db.serialize(() => {
+  db.run(`
+    ALTER TABLE keepers ADD COLUMN trade_from_roster_id INTEGER;
+  `, err => {
+    if (err && err.message.includes('duplicate column name')) {
+      console.log('ℹ️  trade_from_roster_id column already exists');
+    } else if (err) {
+      console.error('❌ Error adding trade_from_roster_id column:', err.message);
+    } else {
+      console.log('✅ Added trade_from_roster_id column');
+    }
+  });
+
+  db.run(`
+    ALTER TABLE keepers ADD COLUMN trade_amount REAL;
+  `, err => {
+    if (err && err.message.includes('duplicate column name')) {
+      console.log('ℹ️  trade_amount column already exists');
+    } else if (err) {
+      console.error('❌ Error adding trade_amount column:', err.message);
+    } else {
+      console.log('✅ Added trade_amount column');
+    }
+  });
+});
+
+db.close(err => {
+  if (err) {
+    console.error('❌ Error closing database:', err.message);
+  } else {
+    console.log('✅ Migration completed and database closed.');
+  }
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -32,6 +32,25 @@ db.serialize(() => {
       PRIMARY KEY (year, roster_id, player_name)
     )
   `);
+
+  // Ensure new trade columns exist for legacy databases
+  db.run(
+    `ALTER TABLE keepers ADD COLUMN trade_from_roster_id INTEGER`,
+    err => {
+      if (err && !err.message.includes('duplicate column name')) {
+        console.error('Error adding trade_from_roster_id column:', err.message);
+      }
+    }
+  );
+
+  db.run(
+    `ALTER TABLE keepers ADD COLUMN trade_amount REAL`,
+    err => {
+      if (err && !err.message.includes('duplicate column name')) {
+        console.error('Error adding trade_amount column:', err.message);
+      }
+    }
+  );
 });
 
 // Helper functions for async DB operations


### PR DESCRIPTION
## Summary
- ensure `keepers` table includes trade columns
- add migration to extend existing databases

## Testing
- `cd backend && npm test` *(fails: Missing script "test")*
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f91507d4833287417c39ff942fdc