### PR TITLE
Allow editing traded keepers and fix years-kept count

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -255,10 +255,10 @@ app.post('/api/keepers/:year/:rosterId', async (req, res) => {
 
     for (const p of players) {
       const prev = await getAsync(
-        'SELECT years_kept FROM keepers WHERE year = ? AND roster_id = ? AND player_name = ?',
-        [year - 1, rosterId, p.name]
+        'SELECT years_kept FROM keepers WHERE year = ? AND player_name = ?',
+        [year - 1, p.name]
       );
-      const yearsKept = prev ? prev.years_kept + 1 : 1;
+      const yearsKept = prev ? prev.years_kept + 1 : 0;
       await runAsync(
         'INSERT INTO keepers (year, roster_id, player_name, previous_cost, years_kept, trade_from_roster_id, trade_amount) VALUES (?, ?, ?, ?, ?, ?, ?)',
         [year, rosterId, p.name, p.previous_cost, yearsKept, p.trade_from_roster_id || null, p.trade_amount || null]

--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -246,7 +246,7 @@ const FantasyFootballApp = () => {
               trade: true,
               trade_roster_id: sp.roster_id,
               trade_amount: sp.trade_amount || '',
-              locked: true
+              locked: false
             });
           }
         });
@@ -271,7 +271,6 @@ const FantasyFootballApp = () => {
       const updated = prev.map(team => ({ ...team, players: [...team.players] }));
       const team = updated.find(t => t.roster_id === rosterId);
       const player = team.players[playerIndex];
-      if (player.locked) return prev;
       team.players[playerIndex] = { ...player, keep: !player.keep };
       team.players.sort((a, b) => (b.previous_cost || 0) - (a.previous_cost || 0));
       return updated;
@@ -1357,7 +1356,6 @@ const FantasyFootballApp = () => {
                                   type="checkbox"
                                   checked={player.keep}
                                   onChange={() => toggleKeeperSelection(selectedKeeperRoster.roster_id, idx)}
-                                  disabled={player.locked}
                                 />
                               </td>
                             </tr>


### PR DESCRIPTION
## Summary
- Permit trade details editing on the roster trading away a player and allow keeper checkbox on traded-in players
- Correct years-kept calculation to only increment when player was kept in prior season

## Testing
- `npm test` *(fails: react-scripts not found due to dependency installation error)*

------
https://chatgpt.com/codex/tasks/task_e_68a60c26add0833296e6bfceac746c86