### PR TITLE
Fix keeper manager selection and trade checkbox behavior

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -256,9 +256,14 @@ const FantasyFootballApp = () => {
       });
 
       setKeepers(processed);
-      setSelectedKeeperRosterId(
-        processed.length > 0 ? processed[0].roster_id : null
-      );
+      const prevManager = keepers.find(t => t.roster_id === selectedKeeperRosterId)?.manager_name;
+      setSelectedKeeperRosterId(() => {
+        if (prevManager) {
+          const match = processed.find(t => t.manager_name === prevManager);
+          if (match) return match.roster_id;
+        }
+        return processed.length > 0 ? processed[0].roster_id : null;
+      });
     } catch (error) {
       console.error('Error fetching keepers:', error);
       setKeepers([]);
@@ -321,7 +326,6 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
         player.trade = false;
         player.trade_roster_id = null;
         player.trade_amount = '';
-        player.keep = true;
       }
 
       sourceTeam.players.sort((a, b) => (b.previous_cost || 0) - (a.previous_cost || 0));


### PR DESCRIPTION
## Summary
- retain selected manager when switching years in Keepers tab
- stop keep checkbox from auto-selecting when trade checkbox is unchecked

## Testing
- `npm install` *(fails: 403 Forbidden - tsutils)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63dc719588332a36d8692ad596c4e