### PR TITLE
Fix keeper year tracking

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -282,7 +282,7 @@ app.post('/api/keepers/:year/:rosterId', async (req, res) => {
         'SELECT years_kept FROM keepers WHERE year = ? AND player_name = ?',
         [year - 1, p.name]
       );
-      const yearsKept = prev ? prev.years_kept + 1 : 0;
+      const yearsKept = prev ? prev.years_kept : 0;
       await runAsync(
         'INSERT INTO keepers (year, roster_id, player_name, previous_cost, years_kept, trade_from_roster_id, trade_amount) VALUES (?, ?, ?, ?, ?, ?, ?)',
         [year, rosterId, p.name, p.previous_cost, yearsKept, p.trade_from_roster_id || null, p.trade_amount || null]

--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -220,7 +220,7 @@ const FantasyFootballApp = () => {
               name: p.name,
               previous_cost: p.draft_cost || '',
               base_years_kept: baseYears,
-              years_kept: keep ? baseYears + 1 : 0,
+              years_kept: keep ? baseYears : 0,
               keep,
               trade: savedPlayer ? savedPlayer.trade_from_roster_id != null : false,
               trade_roster_id: savedPlayer ? savedPlayer.trade_from_roster_id : null,
@@ -236,7 +236,7 @@ const FantasyFootballApp = () => {
               name: sp.player_name,
               previous_cost: sp.previous_cost,
               base_years_kept: baseYears,
-              years_kept: baseYears + 1,
+              years_kept: baseYears,
               keep: true,
               trade: sp.trade_from_roster_id != null,
               trade_roster_id: sp.trade_from_roster_id,
@@ -294,7 +294,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
     team.players[playerIndex] = {
       ...player,
       keep: newKeep,
-      years_kept: newKeep ? player.base_years_kept + 1 : 0
+      years_kept: newKeep ? player.base_years_kept : 0
     };
     team.players.sort((a, b) => (b.previous_cost || 0) - (a.previous_cost || 0));
     saveAllKeepers(updated);
@@ -324,7 +324,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
               name: player.name,
               previous_cost: player.previous_cost,
               base_years_kept: player.base_years_kept,
-              years_kept: player.base_years_kept + 1,
+              years_kept: player.base_years_kept,
               keep: true,
               trade: true,
               trade_roster_id: rosterId,
@@ -346,7 +346,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
         player.trade = false;
         player.trade_roster_id = null;
         player.trade_amount = '';
-        player.years_kept = player.keep ? player.base_years_kept + 1 : 0;
+        player.years_kept = player.keep ? player.base_years_kept : 0;
       }
 
       sourceTeam.players.sort((a, b) => (b.previous_cost || 0) - (a.previous_cost || 0));
@@ -385,7 +385,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
             name: player.name,
             previous_cost: player.previous_cost,
             base_years_kept: player.base_years_kept,
-            years_kept: player.base_years_kept + 1,
+            years_kept: player.base_years_kept,
             keep: true,
             trade: true,
             trade_roster_id: rosterId,


### PR DESCRIPTION
## Summary
- avoid incrementing keeper years on save; years increment only on following season
- display base years kept for current-season selections and trade targets

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found; npm install fails with 403 for tsutils)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b792cc883328c6076af95b312ac