### PR TITLE
Increment keeper years across seasons

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -282,7 +282,7 @@ app.post('/api/keepers/:year/:rosterId', async (req, res) => {
         'SELECT years_kept FROM keepers WHERE year = ? AND player_name = ?',
         [year - 1, p.name]
       );
-      const yearsKept = prev ? prev.years_kept : 0;
+      const yearsKept = prev ? prev.years_kept + 1 : 0;
       await runAsync(
         'INSERT INTO keepers (year, roster_id, player_name, previous_cost, years_kept, trade_from_roster_id, trade_amount) VALUES (?, ?, ?, ?, ?, ?, ?)',
         [year, rosterId, p.name, p.previous_cost, yearsKept, p.trade_from_roster_id || null, p.trade_amount || null]

--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -213,7 +213,7 @@ const FantasyFootballApp = () => {
         const players = team.players
           .map(p => {
             const prevPlayer = prevMap[p.name];
-            const baseYears = prevPlayer ? prevPlayer.years_kept : 0;
+            const baseYears = prevPlayer ? prevPlayer.years_kept + 1 : 0;
             const savedPlayer = savedTeam.find(k => k.player_name === p.name);
             const keep = !!savedPlayer;
             return {
@@ -231,7 +231,9 @@ const FantasyFootballApp = () => {
 
         savedTeam.forEach(sp => {
           if (!players.some(p => p.name === sp.player_name)) {
-            const baseYears = prevMap[sp.player_name]?.years_kept || 0;
+            const baseYears = prevMap[sp.player_name]
+              ? prevMap[sp.player_name].years_kept + 1
+              : 0;
             players.push({
               name: sp.player_name,
               previous_cost: sp.previous_cost,
@@ -249,7 +251,9 @@ const FantasyFootballApp = () => {
         const tradedAway = tradedFromMap[team.roster_id] || [];
         tradedAway.forEach(sp => {
           if (!players.some(p => p.name === sp.player_name && p.trade_roster_id === sp.roster_id)) {
-            const baseYears = prevMap[sp.player_name]?.years_kept || 0;
+            const baseYears = prevMap[sp.player_name]
+              ? prevMap[sp.player_name].years_kept + 1
+              : 0;
             players.push({
               name: sp.player_name,
               previous_cost: sp.previous_cost,


### PR DESCRIPTION
## Summary
- Increment stored keeper years based on prior season selections on backend
- Calculate next year's keeper count on initial roster load in the UI

## Testing
- `npm ci --no-fund --no-audit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsutils)*
- `CI=true npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a67d586cf083328042784ad77968cb