### PR TITLE
Fix years kept calculation and display

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -88,7 +88,8 @@ const recalcYearsKeptFrom = async (startYear) => {
         'SELECT years_kept FROM keepers WHERE year = ? AND player_name = ?',
         [y - 1, row.player_name]
       );
-      const yearsKept = prev ? prev.years_kept + 1 : 0;
+      const prevYears = prev ? Math.max(prev.years_kept, 1) : 0;
+      const yearsKept = prevYears + 1;
       await runAsync('UPDATE keepers SET years_kept = ? WHERE rowid = ?', [yearsKept, row.rowid]);
     }
   }
@@ -282,7 +283,8 @@ app.post('/api/keepers/:year/:rosterId', async (req, res) => {
         'SELECT years_kept FROM keepers WHERE year = ? AND player_name = ?',
         [year - 1, p.name]
       );
-      const yearsKept = prev ? prev.years_kept + 1 : 0;
+      const prevYears = prev ? Math.max(prev.years_kept, 1) : 0;
+      const yearsKept = prevYears + 1;
       await runAsync(
         'INSERT INTO keepers (year, roster_id, player_name, previous_cost, years_kept, trade_from_roster_id, trade_amount) VALUES (?, ?, ?, ?, ?, ?, ?)',
         [year, rosterId, p.name, p.previous_cost, yearsKept, p.trade_from_roster_id || null, p.trade_amount || null]

--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -213,14 +213,15 @@ const FantasyFootballApp = () => {
         const players = team.players
           .map(p => {
             const prevPlayer = prevMap[p.name];
-            const baseYears = prevPlayer ? prevPlayer.years_kept + 1 : 0;
+            const prevYears = prevPlayer ? Math.max(prevPlayer.years_kept, 1) : 0;
+            const baseYears = prevYears + 1;
             const savedPlayer = savedTeam.find(k => k.player_name === p.name);
             const keep = !!savedPlayer;
             return {
               name: p.name,
               previous_cost: p.draft_cost || '',
               base_years_kept: baseYears,
-              years_kept: keep ? baseYears : 0,
+              years_kept: keep ? baseYears : prevYears,
               keep,
               trade: savedPlayer ? savedPlayer.trade_from_roster_id != null : false,
               trade_roster_id: savedPlayer ? savedPlayer.trade_from_roster_id : null,
@@ -231,9 +232,10 @@ const FantasyFootballApp = () => {
 
         savedTeam.forEach(sp => {
           if (!players.some(p => p.name === sp.player_name)) {
-            const baseYears = prevMap[sp.player_name]
-              ? prevMap[sp.player_name].years_kept + 1
+            const prevYears = prevMap[sp.player_name]
+              ? Math.max(prevMap[sp.player_name].years_kept, 1)
               : 0;
+            const baseYears = prevYears + 1;
             players.push({
               name: sp.player_name,
               previous_cost: sp.previous_cost,
@@ -251,14 +253,15 @@ const FantasyFootballApp = () => {
         const tradedAway = tradedFromMap[team.roster_id] || [];
         tradedAway.forEach(sp => {
           if (!players.some(p => p.name === sp.player_name && p.trade_roster_id === sp.roster_id)) {
-            const baseYears = prevMap[sp.player_name]
-              ? prevMap[sp.player_name].years_kept + 1
+            const prevYears = prevMap[sp.player_name]
+              ? Math.max(prevMap[sp.player_name].years_kept, 1)
               : 0;
+            const baseYears = prevYears + 1;
             players.push({
               name: sp.player_name,
               previous_cost: sp.previous_cost,
               base_years_kept: baseYears,
-              years_kept: 0,
+              years_kept: prevYears,
               keep: false,
               trade: true,
               trade_roster_id: sp.roster_id,
@@ -298,7 +301,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
     team.players[playerIndex] = {
       ...player,
       keep: newKeep,
-      years_kept: newKeep ? player.base_years_kept : 0
+      years_kept: newKeep ? player.base_years_kept : player.base_years_kept - 1
     };
     team.players.sort((a, b) => (b.previous_cost || 0) - (a.previous_cost || 0));
     saveAllKeepers(updated);
@@ -319,7 +322,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
         player.trade_roster_id = defaultTarget;
         player.trade_amount = '';
         player.keep = false;
-        player.years_kept = 0;
+        player.years_kept = player.base_years_kept - 1;
 
         if (defaultTarget != null) {
           const targetTeam = updated.find(t => t.roster_id === defaultTarget);
@@ -350,7 +353,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
         player.trade = false;
         player.trade_roster_id = null;
         player.trade_amount = '';
-        player.years_kept = player.keep ? player.base_years_kept : 0;
+        player.years_kept = player.keep ? player.base_years_kept : player.base_years_kept - 1;
       }
 
       sourceTeam.players.sort((a, b) => (b.previous_cost || 0) - (a.previous_cost || 0));


### PR DESCRIPTION
## Summary
- ensure backend computes `years_kept` starting at 1 and carries over existing values
- show prior keeper years in UI and adjust counts when toggling keep or trade

## Testing
- `node --check backend/server.js`
- `CI=true npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a685f8c038833293f85f18fdca2350