### PR TITLE
Remove years_kept logic

### DIFF
--- a/backend/scripts/initDatabase.js
+++ b/backend/scripts/initDatabase.js
@@ -120,7 +120,7 @@ db.serialize(() => {
       roster_id INTEGER,
       player_name TEXT,
       previous_cost REAL,
-      years_kept INTEGER,
+      years_kept INTEGER DEFAULT 0,
       trade_from_roster_id INTEGER,
       trade_amount REAL,
       PRIMARY KEY (year, roster_id, player_name)


### PR DESCRIPTION
## Summary
- Remove all years_kept calculations across backend and frontend, resetting values to zero
- Simplify keepers insertion to always store years_kept as 0
- Drop recalcYearsKeptFrom and related logic for a clean slate

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm --prefix backend test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a68e55b19c83329272d7be205f4b90