### PR TITLE
Track keeper years by player

### DIFF
--- a/backend/scripts/initDatabase.js
+++ b/backend/scripts/initDatabase.js
@@ -118,12 +118,13 @@ db.serialize(() => {
     CREATE TABLE IF NOT EXISTS keepers (
       year INTEGER,
       roster_id INTEGER,
+      player_id TEXT,
       player_name TEXT,
       previous_cost REAL,
       years_kept INTEGER DEFAULT 0,
       trade_from_roster_id INTEGER,
       trade_amount REAL,
-      PRIMARY KEY (year, roster_id, player_name)
+      PRIMARY KEY (year, roster_id, player_id)
     )
   `, (err) => {
     if (err) {
@@ -156,6 +157,19 @@ db.serialize(() => {
       console.error('❌ Error adding trade_amount column:', err.message);
     } else {
       console.log('✅ Added trade_amount column');
+    }
+  });
+
+  // Add player_id column if it doesn't exist
+  db.run(`
+    ALTER TABLE keepers ADD COLUMN player_id TEXT;
+  `, (err) => {
+    if (err && err.message.includes('duplicate column name')) {
+      console.log('ℹ️  player_id column already exists');
+    } else if (err) {
+      console.error('❌ Error adding player_id column:', err.message);
+    } else {
+      console.log('✅ Added player_id column');
     }
   });
 
@@ -217,6 +231,10 @@ db.serialize(() => {
     {
       name: 'idx_keepers_year_roster',
       sql: 'CREATE INDEX IF NOT EXISTS idx_keepers_year_roster ON keepers(year, roster_id)'
+    },
+    {
+      name: 'idx_keepers_year_player',
+      sql: 'CREATE INDEX IF NOT EXISTS idx_keepers_year_player ON keepers(year, player_id)'
     },
     {
       name: 'idx_team_seasons_year',

--- a/backend/scripts/migrations/addKeeperPlayerIdColumn.js
+++ b/backend/scripts/migrations/addKeeperPlayerIdColumn.js
@@ -1,0 +1,41 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = path.join(__dirname, '..', '..', 'data', 'fantasy_football.db');
+const db = new sqlite3.Database(dbPath);
+
+console.log('🚀 Running migration: add player_id column to keepers table...');
+
+db.serialize(() => {
+  db.run(
+    `ALTER TABLE keepers ADD COLUMN player_id TEXT;`,
+    err => {
+      if (err && err.message.includes('duplicate column name')) {
+        console.log('ℹ️  player_id column already exists');
+      } else if (err) {
+        console.error('❌ Error adding player_id column:', err.message);
+      } else {
+        console.log('✅ Added player_id column');
+      }
+    }
+  );
+
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_keepers_year_player ON keepers(year, player_id);`,
+    err => {
+      if (err) {
+        console.error('❌ Error creating idx_keepers_year_player index:', err.message);
+      } else {
+        console.log('✅ Created idx_keepers_year_player index');
+      }
+    }
+  );
+});
+
+db.close(err => {
+  if (err) {
+    console.error('❌ Error closing database:', err.message);
+  } else {
+    console.log('✅ Migration completed and database closed.');
+  }
+});

--- a/backend/services/sleeperService.js
+++ b/backend/services/sleeperService.js
@@ -553,6 +553,7 @@ class SleeperService {
                 ? `${p.first_name} ${p.last_name}`
                 : pid);
             return {
+              id: pid,
               name,
               draft_cost: playerCosts[pid] || ''
             };

--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -204,12 +204,13 @@ const FantasyFootballApp = () => {
           k => k.roster_id === team.roster_id && k.trade_from_roster_id !== k.roster_id
         );
         const players = team.players.map(p => {
-          const savedPlayer = savedTeam.find(k => k.player_name === p.name);
+          const savedPlayer = savedTeam.find(k => k.player_id === p.id);
           const keep = !!savedPlayer;
           return {
+            id: p.id,
             name: p.name,
             previous_cost: p.draft_cost || '',
-            years_kept: 0,
+            years_kept: savedPlayer ? savedPlayer.years_kept : 0,
             keep,
             trade: savedPlayer ? savedPlayer.trade_from_roster_id != null : false,
             trade_roster_id: savedPlayer ? savedPlayer.trade_from_roster_id : null,
@@ -219,11 +220,12 @@ const FantasyFootballApp = () => {
         });
 
         savedTeam.forEach(sp => {
-          if (!players.some(p => p.name === sp.player_name)) {
+          if (!players.some(p => p.id === sp.player_id)) {
             players.push({
+              id: sp.player_id,
               name: sp.player_name,
               previous_cost: sp.previous_cost,
-              years_kept: 0,
+              years_kept: sp.years_kept,
               keep: true,
               trade: sp.trade_from_roster_id != null,
               trade_roster_id: sp.trade_from_roster_id,
@@ -235,11 +237,12 @@ const FantasyFootballApp = () => {
 
         const tradedAway = tradedFromMap[team.roster_id] || [];
         tradedAway.forEach(sp => {
-          if (!players.some(p => p.name === sp.player_name && p.trade_roster_id === sp.roster_id)) {
+          if (!players.some(p => p.id === sp.player_id && p.trade_roster_id === sp.roster_id)) {
             players.push({
+              id: sp.player_id,
               name: sp.player_name,
               previous_cost: sp.previous_cost,
-              years_kept: 0,
+              years_kept: sp.years_kept,
               keep: false,
               trade: true,
               trade_roster_id: sp.roster_id,
@@ -304,8 +307,9 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
 
         if (defaultTarget != null) {
           const targetTeam = updated.find(t => t.roster_id === defaultTarget);
-          if (!targetTeam.players.some(p => p.name === player.name && p.locked && p.trade_roster_id === rosterId)) {
+          if (!targetTeam.players.some(p => p.id === player.id && p.locked && p.trade_roster_id === rosterId)) {
             targetTeam.players.push({
+              id: player.id,
               name: player.name,
               previous_cost: player.previous_cost,
               years_kept: 0,
@@ -323,7 +327,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
           const targetTeam = updated.find(t => t.roster_id === player.trade_roster_id);
           if (targetTeam) {
             targetTeam.players = targetTeam.players.filter(
-              p => !(p.name === player.name && p.locked && p.trade_roster_id === rosterId)
+              p => !(p.id === player.id && p.locked && p.trade_roster_id === rosterId)
             );
           }
         }
@@ -356,7 +360,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
         const oldTeam = updated.find(t => t.roster_id === oldTarget);
         if (oldTeam) {
           oldTeam.players = oldTeam.players.filter(
-            p => !(p.name === player.name && p.locked && p.trade_roster_id === rosterId)
+            p => !(p.id === player.id && p.locked && p.trade_roster_id === rosterId)
           );
         }
       }
@@ -364,8 +368,9 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
       // add to new target
       if (newTarget) {
         const newTeam = updated.find(t => t.roster_id === newTarget);
-        if (!newTeam.players.some(p => p.name === player.name && p.locked && p.trade_roster_id === rosterId)) {
+        if (!newTeam.players.some(p => p.id === player.id && p.locked && p.trade_roster_id === rosterId)) {
           newTeam.players.push({
+            id: player.id,
             name: player.name,
             previous_cost: player.previous_cost,
             years_kept: 0,
@@ -397,7 +402,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
       if (player.trade_roster_id) {
         const targetTeam = updated.find(t => t.roster_id === player.trade_roster_id);
         const targetPlayer = targetTeam.players.find(
-          p => p.name === player.name && p.locked && p.trade_roster_id === rosterId
+          p => p.id === player.id && p.locked && p.trade_roster_id === rosterId
         );
         if (targetPlayer) targetPlayer.trade_amount = value;
       }
@@ -419,6 +424,7 @@ const toggleKeeperSelection = (rosterId, playerIndex) => {
       const teamPlayers = team.players
         .filter(p => (p.trade ? p.locked && p.keep : p.keep))
         .map(p => ({
+          player_id: p.id,
           name: p.name,
           previous_cost: p.previous_cost,
           trade_from_roster_id: p.trade ? p.trade_roster_id : null,


### PR DESCRIPTION
## Summary
- store Sleeper `player_id` in keepers table and index by year/player
- calculate `years_kept` from previous season's data on save
- propagate player IDs through API, services, and UI; add migration script

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a69a4e3ee48332bf787251db17d96b