### PR TITLE
Add trade notes and adjust manual trade summary

### DIFF
--- a/backend/scripts/initDatabase.js
+++ b/backend/scripts/initDatabase.js
@@ -124,6 +124,7 @@ db.serialize(() => {
       years_kept INTEGER DEFAULT 0,
       trade_from_roster_id INTEGER,
       trade_amount REAL,
+      trade_note TEXT,
       PRIMARY KEY (year, roster_id, player_id)
     )
   `, (err) => {
@@ -157,6 +158,18 @@ db.serialize(() => {
       console.error('❌ Error adding trade_amount column:', err.message);
     } else {
       console.log('✅ Added trade_amount column');
+    }
+  });
+
+  db.run(`
+    ALTER TABLE keepers ADD COLUMN trade_note TEXT;
+  `, (err) => {
+    if (err && err.message.includes('duplicate column name')) {
+      console.log('ℹ️  trade_note column already exists');
+    } else if (err) {
+      console.error('❌ Error adding trade_note column:', err.message);
+    } else {
+      console.log('✅ Added trade_note column');
     }
   });
 

--- a/backend/scripts/migrations/addKeeperTradeColumns.js
+++ b/backend/scripts/migrations/addKeeperTradeColumns.js
@@ -30,6 +30,18 @@ db.serialize(() => {
       console.log('✅ Added trade_amount column');
     }
   });
+
+  db.run(`
+    ALTER TABLE keepers ADD COLUMN trade_note TEXT;
+  `, err => {
+    if (err && err.message.includes('duplicate column name')) {
+      console.log('ℹ️  trade_note column already exists');
+    } else if (err) {
+      console.error('❌ Error adding trade_note column:', err.message);
+    } else {
+      console.log('✅ Added trade_note column');
+    }
+  });
 });
 
 db.close(err => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -30,6 +30,7 @@ db.serialize(() => {
       years_kept INTEGER DEFAULT 0,
       trade_from_roster_id INTEGER,
       trade_amount REAL,
+      trade_note TEXT,
       PRIMARY KEY (year, roster_id, player_id)
     )
   `);
@@ -49,6 +50,15 @@ db.serialize(() => {
     err => {
       if (err && !err.message.includes('duplicate column name')) {
         console.error('Error adding trade_amount column:', err.message);
+      }
+    }
+  );
+
+  db.run(
+    `ALTER TABLE keepers ADD COLUMN trade_note TEXT`,
+    err => {
+      if (err && !err.message.includes('duplicate column name')) {
+        console.error('Error adding trade_note column:', err.message);
       }
     }
   );
@@ -261,7 +271,7 @@ app.get('/api/seasons/:year/keepers', (req, res) => {
 app.get('/api/keepers/:year', (req, res) => {
   const year = parseInt(req.params.year);
   db.all(
-    'SELECT roster_id, player_id, player_name, previous_cost, years_kept, trade_from_roster_id, trade_amount FROM keepers WHERE year = ?',
+    'SELECT roster_id, player_id, player_name, previous_cost, years_kept, trade_from_roster_id, trade_amount, trade_note FROM keepers WHERE year = ?',
     [year],
     (err, rows) => {
       if (err) {
@@ -290,7 +300,7 @@ app.post('/api/keepers/:year/:rosterId', async (req, res) => {
       const yearsKept = prev ? prev.years_kept + 1 : 0;
 
       await runAsync(
-        'INSERT INTO keepers (year, roster_id, player_id, player_name, previous_cost, years_kept, trade_from_roster_id, trade_amount) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO keepers (year, roster_id, player_id, player_name, previous_cost, years_kept, trade_from_roster_id, trade_amount, trade_note) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
         [
           year,
           rosterId,
@@ -300,6 +310,7 @@ app.post('/api/keepers/:year/:rosterId', async (req, res) => {
           yearsKept,
           p.trade_from_roster_id || null,
           p.trade_amount || null,
+          p.trade_note || null,
         ]
       );
     }

--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -484,6 +484,27 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
     });
   };
 
+  const handleTradeNoteChange = (rosterId, playerIndex, value) => {
+    setKeepers(prev => {
+      const updated = prev.map(team => ({ ...team, players: [...team.players] }));
+      const sourceTeam = updated.find(t => t.roster_id === rosterId);
+      const player = sourceTeam.players[playerIndex];
+      if (player.locked || player.years_kept > 1) return prev;
+
+      player.trade_note = value;
+      if (player.trade_roster_id) {
+        const targetTeam = updated.find(t => t.roster_id === player.trade_roster_id);
+        const targetPlayer = targetTeam.players.find(
+          p => p.id === player.id && p.locked && p.trade_roster_id === rosterId
+        );
+        if (targetPlayer) targetPlayer.trade_note = value;
+      }
+
+      saveAllKeepers(updated);
+      return updated;
+    });
+  };
+
   const getManagerName = (rosterId) => {
     const team = keepers.find(t => t.roster_id === rosterId);
     return team ? team.manager_name || team.team_name || `Roster ${rosterId}` : `Roster ${rosterId}`;
@@ -2266,26 +2287,5 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
     </div>
   );
 };
-
-  const handleTradeNoteChange = (rosterId, playerIndex, value) => {
-    setKeepers(prev => {
-      const updated = prev.map(team => ({ ...team, players: [...team.players] }));
-      const sourceTeam = updated.find(t => t.roster_id === rosterId);
-      const player = sourceTeam.players[playerIndex];
-      if (player.locked || player.years_kept > 1) return prev;
-
-      player.trade_note = value;
-      if (player.trade_roster_id) {
-        const targetTeam = updated.find(t => t.roster_id === player.trade_roster_id);
-        const targetPlayer = targetTeam.players.find(
-          p => p.id === player.id && p.locked && p.trade_roster_id === rosterId
-        );
-        if (targetPlayer) targetPlayer.trade_note = value;
-      }
-
-      saveAllKeepers(updated);
-      return updated;
-    });
-  };
 
 export default FantasyFootballApp;


### PR DESCRIPTION
## Summary
- Flip manual trade cash signs so sender shows negative and receiver positive
- Allow notes on keeper-tab trades and include them in trade summaries
- Reformat trade summary list to show year and note with manual trades first

## Testing
- `npm test -- --watch=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching tsutils)*

------
https://chatgpt.com/codex/tasks/task_e_68a772c165d4833283f500b475782850