### PR TITLE
Remove redundant year label from keeper trades summary

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -1425,8 +1425,8 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
                     {tradeSummary.map((trade, idx) => (
                       <li key={idx}>
                         {trade.manual
-                          ? `${trade.year}: ${trade.from} (-$${trade.amount}) in-season trade to ${trade.to} (+$${trade.amount})${trade.note ? ` - ${trade.note}` : ''}`
-                          : `${trade.year}: ${trade.to} (-$${trade.amount}) buys ${trade.player} from ${trade.from} (+$${trade.amount})${trade.note ? ` - ${trade.note}` : ''}`}
+                          ? `${trade.from} (-$${trade.amount}) in-season trade to ${trade.to} (+$${trade.amount})${trade.note ? ` - ${trade.note}` : ''}`
+                          : `${trade.to} (-$${trade.amount}) buys ${trade.player} from ${trade.from} (+$${trade.amount})${trade.note ? ` - ${trade.note}` : ''}`}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- Remove year prefix from keeper and manual trade summaries in the Keepers tab

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a786e6bda08332ae77f0222c7f29af