### PR TITLE
Ignore zero weekly scores

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -1122,12 +1122,14 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
   };
 
   const weeklyScores = useMemo(() => {
-    return seasonMatchups.flatMap(week =>
-      week.matchups.flatMap(m => [
-        { manager: m.home.manager_name, points: m.home.points, week: week.week },
-        { manager: m.away.manager_name, points: m.away.points, week: week.week }
-      ])
-    );
+    return seasonMatchups
+      .flatMap(week =>
+        week.matchups.flatMap(m => [
+          { manager: m.home.manager_name, points: m.home.points, week: week.week },
+          { manager: m.away.manager_name, points: m.away.points, week: week.week }
+        ])
+      )
+      .filter(score => score.points > 0);
   }, [seasonMatchups]);
 
   const topWeeklyScores = [...weeklyScores].sort((a, b) => b.points - a.points).slice(0, 5);


### PR DESCRIPTION
## Summary
- exclude matchups with zero points when computing weekly score lists

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0930026c08332ba67d8566c33f529