### PR TITLE
Make summary endpoint rate limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A comprehensive web application for tracking fantasy football league records, st
   - Champion plaque engraving instructions
 
 - **LLM Summaries**: Generate AI-based summaries via `POST /api/summarize` (requires `OPENAI_API_KEY` in `backend/.env`)
+- **Rate Limiting**: Summary endpoint allows 20 requests per minute by default and can be tuned with `SUMMARY_RATE_LIMIT_MAX` and `SUMMARY_RATE_LIMIT_WINDOW_MS` variables
 
 ## Quick Start
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for backend
+# Adjust summary endpoint rate limiting
+SUMMARY_RATE_LIMIT_MAX=20
+SUMMARY_RATE_LIMIT_WINDOW_MS=60000

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,9 +13,14 @@ const app = express();
 const PORT = process.env.PORT || 3001;
 
 // Rate limiter for summary endpoint
+const summaryRateLimitWindowMs =
+  parseInt(process.env.SUMMARY_RATE_LIMIT_WINDOW_MS, 10) || 60 * 1000;
+const summaryRateLimitMax =
+  parseInt(process.env.SUMMARY_RATE_LIMIT_MAX, 10) || 20;
+
 const summarizeLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 5,
+  windowMs: summaryRateLimitWindowMs,
+  max: summaryRateLimitMax,
   message: 'Too many requests, please try again later.'
 });
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,11 +12,13 @@ REPO_NAME="ff-dashboard"
 IMAGE_TAG="${2:-latest}"
 CONTAINER_NAME="ff-dashboard"
 PORT="${3:-3000}"
+SUMMARY_RATE_LIMIT_MAX="${4:-20}"
 
 echo "🚀 Deploying FF Dashboard"
 echo "   Registry: $REGISTRY"
 echo "   Image: $USERNAME/$REPO_NAME:$IMAGE_TAG"
 echo "   Port: $PORT"
+echo "   Summary rate limit max: $SUMMARY_RATE_LIMIT_MAX"
 echo ""
 
 # Function to check if container exists
@@ -50,6 +52,7 @@ docker run -d \
     --restart unless-stopped \
     -p $PORT:3000 \
     -e NODE_ENV=production \
+    -e SUMMARY_RATE_LIMIT_MAX=$SUMMARY_RATE_LIMIT_MAX \
     $REGISTRY/$USERNAME/$REPO_NAME:$IMAGE_TAG
 
 # Check if container started successfully

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,8 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
       - FAST_REFRESH=true
+      - SUMMARY_RATE_LIMIT_MAX=${SUMMARY_RATE_LIMIT_MAX:-20}
+      - SUMMARY_RATE_LIMIT_WINDOW_MS=${SUMMARY_RATE_LIMIT_WINDOW_MS:-60000}
     networks:
       - fantasy-dev-network
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
+      - SUMMARY_RATE_LIMIT_MAX=${SUMMARY_RATE_LIMIT_MAX:-20}
+      - SUMMARY_RATE_LIMIT_WINDOW_MS=${SUMMARY_RATE_LIMIT_WINDOW_MS:-60000}
     volumes:
       - ff-data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- allow customizing summary endpoint rate limit via SUMMARY_RATE_LIMIT_MAX and SUMMARY_RATE_LIMIT_WINDOW_MS env vars
- expose SUMMARY_RATE_LIMIT_MAX in deploy script and compose files for easy tuning
- document new variables and provide example .env

## Testing
- `npm install` *(fails: 403 Forbidden on tsutils)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `cd backend && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1b95b764083329cbb11fd359164e9