### PR TITLE
Refine season AI summary

### DIFF
--- a/backend/services/summaryService.js
+++ b/backend/services/summaryService.js
@@ -13,6 +13,10 @@ function buildSummaryPrompt(data) {
   const d = typeof data === 'object' && data !== null ? data : {};
   const sections = [];
 
+  if (typeof d.currentWeek === 'number') {
+    sections.push(`Current week: ${d.currentWeek}`);
+  }
+
   // Managers and win/loss records
   const managerRecords = [];
   const managers = new Set();
@@ -74,13 +78,14 @@ function buildSummaryPrompt(data) {
     : [];
   const matchupLines = [];
   matchups.forEach(m => {
+    const weekLabel = m.week ? `W${m.week} ` : '';
     if (m.home && m.away) {
       matchupLines.push(
-        `${m.home.manager_name} vs ${m.away.manager_name} (${m.home.points}-${m.away.points})`
+        `${weekLabel}${m.home.manager_name} vs ${m.away.manager_name} (${m.home.points}-${m.away.points})`
       );
     } else if (m.team1 && m.team2) {
       matchupLines.push(
-        `${m.team1.manager_name} vs ${m.team2.manager_name} (${m.team1.points}-${m.team2.points})`
+        `${weekLabel}${m.team1.manager_name} vs ${m.team2.manager_name} (${m.team1.points}-${m.team2.points})`
       );
     }
   });
@@ -97,7 +102,7 @@ function buildSummaryPrompt(data) {
   const intro = variants[d.type] ||
     'Surface insights about manager performance, medals, win/loss records, roster highlights, and matchups.';
 
-  return `${intro}\n\n${sections.join('\n')}`;
+  return `${intro}\n\n${sections.join('\n')}\n\nFormat the response as concise bullet points.`;
 }
 
 /**

--- a/src/components/AISummary.js
+++ b/src/components/AISummary.js
@@ -48,8 +48,18 @@ const AISummary = ({ data }) => {
   if (!summary) {
     return null;
   }
+  const lines = summary
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line);
 
-  return <p>{summary}</p>;
+  return (
+    <ul className="list-disc list-inside space-y-1">
+      {lines.map((line, idx) => (
+        <li key={idx}>{line.replace(/^[-*]\s*/, '')}</li>
+      ))}
+    </ul>
+  );
 };
 
 export default AISummary;

--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -1175,26 +1175,6 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
       return a.seasons - b.seasons; // Fewer seasons = worse ranking when tied
     });
 
-  const recordsSummaryData = useMemo(
-    () => ({
-      type: 'records',
-      currentChampion,
-      currentChumpion,
-      medalRankings,
-      chumpionRankings,
-      activeRecords,
-      inactiveRecords
-    }),
-    [
-      currentChampion,
-      currentChumpion,
-      medalRankings,
-      chumpionRankings,
-      activeRecords,
-      inactiveRecords
-    ]
-  );
-
   const availableYears = [...new Set(teamSeasons.map(s => s.year))].sort((a, b) => b - a);
   const champion = teamSeasons.find(s => s.year === selectedSeasonYear && s.playoff_finish === 1);
   const runnerUp = teamSeasons.find(s => s.year === selectedSeasonYear && s.playoff_finish === 2);
@@ -1209,7 +1189,14 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
       thirdPlace,
       teams: teamSeasons.filter(s => s.year === selectedSeasonYear),
       topWeeklyScores,
-      bottomWeeklyScores
+      bottomWeeklyScores,
+      matchups: seasonMatchups.flatMap(week =>
+        week.matchups.map(m => ({ ...m, week: week.week }))
+      ),
+      currentWeek:
+        seasonMatchups.length > 0
+          ? Math.max(...seasonMatchups.map(w => w.week))
+          : null
     }),
     [
       selectedSeasonYear,
@@ -1218,7 +1205,8 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
       thirdPlace,
       teamSeasons,
       topWeeklyScores,
-      bottomWeeklyScores
+      bottomWeeklyScores,
+      seasonMatchups
     ]
   );
 
@@ -1350,7 +1338,9 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         {activeTab === 'seasons' && (
           <div className="space-y-4 sm:space-y-6">
-            <AISummary data={seasonSummaryData} />
+            {selectedSeasonYear === mostRecentYear && (
+              <AISummary data={seasonSummaryData} />
+            )}
             <div className="bg-white rounded-xl shadow-lg p-4 sm:p-6">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
                 <h2 className="text-xl sm:text-2xl font-bold text-gray-900 mb-2 sm:mb-0">Season {selectedSeasonYear}</h2>
@@ -1708,7 +1698,6 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
         )}
         {activeTab === 'records' && (
           <div className="space-y-6 sm:space-y-8">
-            <AISummary data={recordsSummaryData} />
             {/* Champion and Chumpion Cards */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
               {/* Champion Card */}


### PR DESCRIPTION
## Summary
- improve summary prompt with current week and matchup context, and request bullet-point formatting
- display AI summary as a bullet list and only for the active season
- drop AI summary from Hall of Records

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c9d719688332a1114616f6964b4d