### PR TITLE
Refactor admin tab headers and AI summary section

### DIFF
--- a/src/components/FantasyFootballApp.js
+++ b/src/components/FantasyFootballApp.js
@@ -2010,10 +2010,10 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
               API_BASE_URL={API_BASE_URL}
               onDataUpdate={fetchData}  // This will refresh your data after sync
             />
-            {/* Manual Trades Section */}
+            {/* Record a Trade Section */}
             <div className="bg-white rounded-xl shadow-lg p-4 sm:p-6">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
-                <h3 className="text-lg sm:text-xl font-bold text-gray-900">Manual Trades</h3>
+                <h3 className="text-lg sm:text-xl font-bold text-gray-900">Record a Trade</h3>
                 <select
                   value={selectedKeeperYear || ''}
                   onChange={e => setSelectedKeeperYear(Number(e.target.value))}
@@ -2106,7 +2106,7 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
             <div className="bg-white rounded-xl shadow-lg p-4 sm:p-6">
               <h3 className="text-lg sm:text-xl font-bold text-gray-900 mb-4 sm:mb-6 flex items-center space-x-2">
                 <Upload className="w-5 h-5 text-blue-500" />
-                <span>Data Management</span>
+                <span>Data Upload</span>
               </h3>
               
               <div className="space-y-4">
@@ -2158,7 +2158,7 @@ const handleTradeAmountChange = (rosterId, playerIndex, value) => {
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 sm:mb-6 space-y-2 sm:space-y-0">
                 <h3 className="text-lg sm:text-xl font-bold text-gray-900 flex items-center space-x-2">
                   <Users className="w-5 h-5 text-blue-500" />
-                  <span>Manager Data</span>
+                  <span>Manager IDs</span>
                 </h3>
               </div>
               

--- a/src/components/FantasyFootballApp_backup.js
+++ b/src/components/FantasyFootballApp_backup.js
@@ -1025,7 +1025,7 @@ const FantasyFootballApp = () => {
             <div className="bg-white rounded-xl shadow-lg p-4 sm:p-6">
               <h3 className="text-lg sm:text-xl font-bold text-gray-900 mb-4 sm:mb-6 flex items-center space-x-2">
                 <Upload className="w-5 h-5 text-blue-500" />
-                <span>Data Management</span>
+                <span>Data Upload</span>
               </h3>
               
               <div className="space-y-4">
@@ -1077,7 +1077,7 @@ const FantasyFootballApp = () => {
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 sm:mb-6 space-y-2 sm:space-y-0">
                 <h3 className="text-lg sm:text-xl font-bold text-gray-900 flex items-center space-x-2">
                   <Users className="w-5 h-5 text-blue-500" />
-                  <span>Manager Data</span>
+                  <span>Manager IDs</span>
                 </h3>
               </div>
               

--- a/src/components/SleeperAdmin.js
+++ b/src/components/SleeperAdmin.js
@@ -271,6 +271,11 @@ const SleeperAdmin = ({ API_BASE_URL, onDataUpdate }) => {
           Enter Sleeper league IDs for each year to sync data automatically.
           Manual fields (dues, payouts, dues_chumpion) will be preserved during sync.
         </div>
+      </div>
+
+      {/* AI Summary Config */}
+      <div className="bg-white rounded-xl shadow-lg p-6">
+        <h4 className="text-lg font-semibold mb-4">AI Summary Config</h4>
         <button
           onClick={refreshSummary}
           className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
@@ -280,10 +285,10 @@ const SleeperAdmin = ({ API_BASE_URL, onDataUpdate }) => {
         </button>
       </div>
 
-      {/* League Settings Table */}
+      {/* League ID History */}
       <div className="bg-white rounded-xl shadow-lg overflow-hidden">
         <div className="p-6">
-          <h4 className="text-lg font-semibold mb-4">League Configuration</h4>
+          <h4 className="text-lg font-semibold mb-4">League ID History</h4>
           
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
@@ -384,10 +389,10 @@ const SleeperAdmin = ({ API_BASE_URL, onDataUpdate }) => {
       </div>
     </div>
 
-    {/* Manager Sleeper ID mappings */}
+    {/* Manager ID Aliases mappings */}
     <div className="bg-white rounded-xl shadow-lg overflow-hidden">
       <div className="p-6">
-        <h4 className="text-lg font-semibold mb-4">Manager Sleeper IDs</h4>
+        <h4 className="text-lg font-semibold mb-4">Manager ID Aliases</h4>
         <div className="flex flex-wrap items-center gap-2 mb-4">
           <select
             className="border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"


### PR DESCRIPTION
## Summary
- Move "Refresh AI Summary" control to new "AI Summary Config" section
- Rename admin tab headers: Record a Trade, League ID History, Manager ID Aliases, Data Upload, and Manager IDs
- Keep backup component headers in sync

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching tsutils)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e52a1b0c8332b5c5581e95f3403f