### PR TITLE
Fix weekly preview matchups

### DIFF
--- a/backend/services/sleeperService.js
+++ b/backend/services/sleeperService.js
@@ -691,6 +691,19 @@ class SleeperService {
   }
 
   /**
+   * Get the current NFL week
+   */
+  async getCurrentNFLWeek() {
+    try {
+      const response = await this.client.get('/state/nfl');
+      return response.data.week;
+    } catch (error) {
+      console.error('❌ Error fetching current NFL week:', error.message);
+      return null;
+    }
+  }
+
+  /**
    * Validate that we can connect to Sleeper API
    */
   async testConnection() {


### PR DESCRIPTION
## Summary
- use Sleeper NFL state to determine current week
- scope season summary data to weeks already played
- build preview matchups for the upcoming week using current season context
- restrict Week In Review metrics to the most recent completed week

## Testing
- `npm test -- --watchAll=false --passWithNoTests` *(fails: react-scripts not found)*
- `npm --prefix backend test` *(fails: Missing script "test")*
- `npm install react-scripts@5.0.1` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c60ad0af0c83329936a904efec728d