### PR TITLE
Include section titles in AI weekly prompts

### DIFF
--- a/backend/services/summaryService.js
+++ b/backend/services/summaryService.js
@@ -12,6 +12,7 @@ function buildSummaryPrompt(data) {
   // Normalize to object
   const d = typeof data === 'object' && data !== null ? data : {};
   const sections = [];
+  const title = typeof d.title === 'string' ? d.title : '';
 
   if (typeof d.currentWeek === 'number') {
     sections.push(`Current week: ${d.currentWeek}`);
@@ -154,7 +155,8 @@ function buildSummaryPrompt(data) {
     variants[d.type] ||
     'Surface insights about manager performance, medals, win/loss records, roster highlights, matchups, and Hall of Records trends. Highlight potential changes in all-time rankings.';
 
-  return `${intro}\n\n${sections.join('\n')}\n\nFormat the response as concise bullet points.`;
+  const titleBlock = title ? `${title}\n\n` : '';
+  return `${titleBlock}${intro}\n\n${sections.join('\n')}\n\nFormat the response as concise bullet points.`;
 }
 
 /**

--- a/backend/services/weeklySummaryService.js
+++ b/backend/services/weeklySummaryService.js
@@ -73,6 +73,7 @@ async function buildSeasonSummaryData(db) {
   let topWeeklyScores = [];
   let bottomWeeklyScores = [];
   let currentWeek = null;
+  let title = null;
 
   if (leagueRow && leagueRow.league_id) {
     const weeks = await sleeperService.getSeasonMatchups(
@@ -102,6 +103,8 @@ async function buildSeasonSummaryData(db) {
       bottomWeeklyScores = [...scores]
         .sort((a, b) => a.points - b.points)
         .slice(0, 5);
+      title = `Week ${lastWeek.week} In Review`;
+      currentWeek = lastWeek.week;
     }
   }
 
@@ -115,7 +118,8 @@ async function buildSeasonSummaryData(db) {
     topWeeklyScores,
     bottomWeeklyScores,
     matchups,
-    currentWeek
+    currentWeek,
+    title
   };
 }
 
@@ -151,6 +155,7 @@ async function buildPreviewData(db) {
 
   let matchups = [];
   let nextWeek = null;
+  let title = null;
 
   if (leagueRow && leagueRow.league_id) {
     const weeks = await sleeperService.getSeasonMatchups(
@@ -176,10 +181,11 @@ async function buildPreviewData(db) {
           }
         };
       });
+      title = `Week ${nextWeek} Preview`;
     }
   }
 
-  return { type: 'preview', year, teams, matchups, currentWeek: nextWeek };
+  return { type: 'preview', year, teams, matchups, currentWeek: nextWeek, title };
 }
 
 async function generateWeeklyPreview(db) {


### PR DESCRIPTION
## Summary
- Add week-specific titles to weekly summary and preview data passed to the AI
- Prepend section titles to AI prompt for clearer week context

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60ec8950c833286bf6da942af951a